### PR TITLE
[fix typos]

### DIFF
--- a/pages/websites/[seed]/edit.js
+++ b/pages/websites/[seed]/edit.js
@@ -33,7 +33,7 @@ const Edit = ({ seed }) => {
   if (isError) return <div>failed to load</div>;
 
   return (
-    <div className="p-6 h-full">
+    <div className="h-full p-6">
       <div className="flex justify-center">
         <div>
           <PageHeading title={"Edit Website"} breadcumbs={breadcumbs} />
@@ -45,23 +45,36 @@ const Edit = ({ seed }) => {
                   <div className="space-y-8 divide-y divide-gray-200">
                     <div className="space-y-8 divide-y divide-gray-200">
                       <div>
-                        <div className="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
+                        <div className="grid grid-cols-1 mt-6 gap-y-6 gap-x-4 sm:grid-cols-6">
                           <div className="sm:col-span-6">
-                            <TextField label="Website Name" name="name" type="text" autocomplete="none" />
+                            <TextField
+                              label="Website Name"
+                              name="name"
+                              type="text"
+                              autocomplete="none"
+                            />
                           </div>
 
                           <div className="sm:col-span-6">
-                            <TextField label="Website URL" name="url" type="text" autocomplete="none" />
+                            <TextField
+                              label="Website URL"
+                              name="url"
+                              type="text"
+                              autocomplete="none"
+                            />
                           </div>
                         </div>
                       </div>
 
                       <div className="pt-8">
                         <div>
-                          <h3 className="text-lg leading-6 font-medium text-gray-900">Share Statistics</h3>
+                          <h3 className="text-lg font-medium leading-6 text-gray-900">
+                            Share Statistics
+                          </h3>
                           <p className="mt-1 text-sm text-gray-500">
-                            If you select to share statistics, a public URL will be available presenting a read-only
-                            version of the Aurora Dashboard. You can disable it later.
+                            If you choose to make statistics public, a public URL will be available
+                            presenting a read-only version of the Aurora Dashboard. Don't worry, you
+                            can disable it later!
                           </p>
                         </div>
 
@@ -69,7 +82,11 @@ const Edit = ({ seed }) => {
                           <fieldset>
                             <div className="space-y-4">
                               <Radio value="1" label="Yes, make it public." name="shared" />
-                              <Radio value="0" label="Nope, i wanna keep it private." name="shared" />
+                              <Radio
+                                value="0"
+                                label="Nope, I want to keep it private."
+                                name="shared"
+                              />
                             </div>
                           </fieldset>
 
@@ -83,12 +100,18 @@ const Edit = ({ seed }) => {
 
                       <div className="pt-8">
                         <div>
-                          <h3 className="text-lg leading-6 font-medium text-gray-900">Connect Your Website</h3>
-                          <p className="mt-1 text-sm text-gray-500">Copy this line of code in the HEAD of your page.</p>
+                          <h3 className="text-lg font-medium leading-6 text-gray-900">
+                            Connect Your Website
+                          </h3>
+                          <p className="mt-1 text-sm text-gray-500">
+                            Copy this line of code in the HEAD of your page.
+                          </p>
                         </div>
 
                         <div className="mt-6 text-sm font-medium text-gray-700">
-                          {`<script async defer src="${window.location.protocol}//${window.location.hostname}${
+                          {`<script async defer src="${window.location.protocol}//${
+                            window.location.hostname
+                          }${
                             location.port ? ":" + location.port : ""
                           }/aurora.js" aurora-id="${seed}"></script>`}
                         </div>

--- a/pages/websites/[seed]/edit.js
+++ b/pages/websites/[seed]/edit.js
@@ -74,7 +74,7 @@ const Edit = ({ seed }) => {
                           <p className="mt-1 text-sm text-gray-500">
                             If you choose to make statistics public, a public URL will be available
                             presenting a read-only version of the Aurora Dashboard. Don't worry, you
-                            can disable it later!
+                            can always disable it later!
                           </p>
                         </div>
 

--- a/pages/websites/create.js
+++ b/pages/websites/create.js
@@ -20,7 +20,7 @@ const Create = () => {
       .finally(setSubmitting(false));
 
   return (
-    <div className="p-6 h-full">
+    <div className="h-full p-6">
       <div className="flex justify-center">
         <div>
           <PageHeading title={"Create Website"} breadcumbs={breadcumbs} />
@@ -32,30 +32,47 @@ const Create = () => {
                   <div className="space-y-8 divide-y divide-gray-200">
                     <div className="space-y-8 divide-y divide-gray-200">
                       <div>
-                        <div className="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
+                        <div className="grid grid-cols-1 mt-6 gap-y-6 gap-x-4 sm:grid-cols-6">
                           <div className="sm:col-span-6">
-                            <TextField label="Website Name" name="name" type="text" autocomplete="none" />
+                            <TextField
+                              label="Website Name"
+                              name="name"
+                              type="text"
+                              autocomplete="none"
+                            />
                           </div>
 
                           <div className="sm:col-span-6">
-                            <TextField label="Website URL" name="url" type="text" autocomplete="none" />
+                            <TextField
+                              label="Website URL"
+                              name="url"
+                              type="text"
+                              autocomplete="none"
+                            />
                           </div>
                         </div>
                       </div>
 
                       <div className="pt-8">
                         <div>
-                          <h3 className="text-lg leading-6 font-medium text-gray-900">Share Statistics</h3>
+                          <h3 className="text-lg font-medium leading-6 text-gray-900">
+                            Share Statistics
+                          </h3>
                           <p className="mt-1 text-sm text-gray-500">
-                            If you select to share statistics, a public URL will be available presenting a read-only
-                            version of the Aurora Dashboard. You can disable it later.
+                            If you choose to make statistics public, a public URL will be available
+                            presenting a read-only version of the Aurora Dashboard. Don't worry, you
+                            can disable it later!
                           </p>
                         </div>
                         <div className="mt-6">
                           <fieldset>
                             <div className="space-y-4">
                               <Radio value="1" label="Yes, make it public." name="shared" />
-                              <Radio value="0" label="Nope, i wanna keep it private." name="shared" />
+                              <Radio
+                                value="0"
+                                label="Nope, I want to keep it private."
+                                name="shared"
+                              />
                             </div>
                           </fieldset>
                         </div>

--- a/pages/websites/create.js
+++ b/pages/websites/create.js
@@ -20,7 +20,7 @@ const Create = () => {
       .finally(setSubmitting(false));
 
   return (
-    <div className="h-full p-6">
+    <div className="p-6 h-full">
       <div className="flex justify-center">
         <div>
           <PageHeading title={"Create Website"} breadcumbs={breadcumbs} />
@@ -32,7 +32,7 @@ const Create = () => {
                   <div className="space-y-8 divide-y divide-gray-200">
                     <div className="space-y-8 divide-y divide-gray-200">
                       <div>
-                        <div className="grid grid-cols-1 mt-6 gap-y-6 gap-x-4 sm:grid-cols-6">
+                        <div className="mt-6 grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-6">
                           <div className="sm:col-span-6">
                             <TextField
                               label="Website Name"
@@ -55,13 +55,13 @@ const Create = () => {
 
                       <div className="pt-8">
                         <div>
-                          <h3 className="text-lg font-medium leading-6 text-gray-900">
+                          <h3 className="text-lg leading-6 font-medium text-gray-900">
                             Share Statistics
                           </h3>
                           <p className="mt-1 text-sm text-gray-500">
                             If you choose to make statistics public, a public URL will be available
                             presenting a read-only version of the Aurora Dashboard. Don't worry, you
-                            can disable it later!
+                            can always disable it later!
                           </p>
                         </div>
                         <div className="mt-6">


### PR DESCRIPTION
I also use a tailwind plugin to reformat classNames as well as prettier so it looks to be a lot of changes but here's what I've done:

1] "If you select to share statistics, a public URL will be available presenting a read-only version of the Aurora Dashboard. You can disable it later." -> "If you choose to make statistics public, a public URL will be available presenting a read-only version of the Aurora Dashboard. Don't worry, you can disable it later!"

2] "Nope, i wanna keep it private." -> "Nope, I want to keep it private."
